### PR TITLE
edit user_model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   has_many :dogs, dependent: :destroy
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
-  belongs_to :prefecture
+  belongs_to :prefecture, optional: true
 
   validates :nickname, presence: true
 end


### PR DESCRIPTION
# WHAT
edit-user_model
# WHY
prefecture_idカラムがnilでもuser登録出来るようにする為